### PR TITLE
Bugfix/ /processing of nested selectors in assertions

### DIFF
--- a/src/spring-mongo/src/main/java/net/conology/spring/restjsonpath/mongo/ir/MongoElementMatch.java
+++ b/src/spring-mongo/src/main/java/net/conology/spring/restjsonpath/mongo/ir/MongoElementMatch.java
@@ -10,6 +10,10 @@ public final class MongoElementMatch implements MongoPropertyAssertion {
         this.propertyTests = propertyTests;
     }
 
+    public MongoAllOfSelector getTests() {
+        return propertyTests;
+    }
+
     public void addTest(MongoPropertyCondition test) {
         propertyTests.addTest(test);
     }

--- a/src/spring-mongo/src/main/java/net/conology/spring/restjsonpath/mongo/postprocessor/AbstractMongoTestPostProcessor.java
+++ b/src/spring-mongo/src/main/java/net/conology/spring/restjsonpath/mongo/postprocessor/AbstractMongoTestPostProcessor.java
@@ -1,10 +1,7 @@
 package net.conology.spring.restjsonpath.mongo.postprocessor;
 
 import net.conology.restjsonpath.PostProcessor;
-import net.conology.spring.restjsonpath.mongo.ir.MongoAllOfSelector;
-import net.conology.spring.restjsonpath.mongo.ir.MongoAnyOfSelector;
-import net.conology.spring.restjsonpath.mongo.ir.MongoPropertyCondition;
-import net.conology.spring.restjsonpath.mongo.ir.MongoSelector;
+import net.conology.spring.restjsonpath.mongo.ir.*;
 
 public abstract class AbstractMongoTestPostProcessor implements PostProcessor<MongoSelector> {
 
@@ -14,8 +11,13 @@ public abstract class AbstractMongoTestPostProcessor implements PostProcessor<Mo
             case MongoAllOfSelector allOfNode ->
                 allOfNode.getTests().forEach(this::accept);
             case MongoAnyOfSelector anyOfNode ->
-                anyOfNode.getAllOfSelectors().forEach(selector -> selector.getTests().forEach(this::accept));
-            case MongoPropertyCondition testNode -> accept(testNode);
+                anyOfNode.getAllOfSelectors().forEach(this::accept);
+            case MongoPropertyCondition testNode -> {
+                accept(testNode);
+                if(testNode.getAssertion() instanceof MongoElementMatch elemMatch) {
+                    accept(elemMatch.getTests());
+                }
+            }
         }
     }
 

--- a/src/spring-mongo/src/test/java/net/conology/spring/restjsonpath/mongo/postprocessor/SimpleFieldNameMapperTest.java
+++ b/src/spring-mongo/src/test/java/net/conology/spring/restjsonpath/mongo/postprocessor/SimpleFieldNameMapperTest.java
@@ -1,0 +1,51 @@
+package net.conology.spring.restjsonpath.mongo.postprocessor;
+
+import net.conology.restjsonpath.ast.ComparisonOperator;
+import net.conology.spring.restjsonpath.mongo.ir.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleFieldNameMapperTest {
+
+    @Test
+    void itMapsFieldNames() {
+        var allOfSelector = new MongoAllOfSelector(
+            List.of(new MongoPropertyCondition(
+                new MongoFieldSelector(List.of("id")),
+                    new MongoValueComparingAssertion(ComparisonOperator.EQ, "test2")
+            ))
+        );
+
+        var query = new MongoAllOfSelector(
+            List.of(
+                new MongoPropertyCondition(
+                    new MongoFieldSelector(List.of("store", "id")),
+                    new MongoValueComparingAssertion(ComparisonOperator.EQ, "test")
+                ),
+                new MongoPropertyCondition(
+                    new MongoFieldSelector(List.of("store", "books")),
+                    new MongoElementMatch(allOfSelector)
+                )
+            )
+        );
+
+        var simpleFieldNameMapper = new SimpleFieldNameMapper(Map.of("id", "_id"));
+
+        simpleFieldNameMapper.accept(query);
+
+        var firstFieldName = ((MongoPropertyCondition) query.getTests().getFirst()).getPropertySelector().getFieldName();
+        var secondFieldName = ((MongoPropertyCondition) (
+            (MongoElementMatch)(
+                (MongoPropertyCondition) query.getTests().getLast()).getAssertion()
+            ).getTests().getTests().getFirst()
+        ).getPropertySelector().getFieldName();
+
+        assertThat(firstFieldName).isEqualTo("_id");
+        assertThat(secondFieldName).isEqualTo("_id");
+
+    }
+}

--- a/src/spring-mongo/src/test/resources/MongoCriteriaCompilerPassTest.csv
+++ b/src/spring-mongo/src/test/resources/MongoCriteriaCompilerPassTest.csv
@@ -65,7 +65,7 @@ test[invalid,!invalidQuery,,
 "@.store.title == ""Amazing""","{""store.title"": ""Amazing""}",,
 [?@.title],!invalidQuery:root query must always start with a property selection,,
 [0],"{""0"": {""$exists"": true, ""$ne"": null, ""$not"": {""$size"": 0}}}",,
-"books[?@[""@type""]]","{""books"": {""$elemMatch"": {""@type"": {""$exists"": true, ""$ne"": null, ""$not"": {""$size"": 0}}}}}",,
+"books[?@[""@type""]]","{""books"": {""$elemMatch"": {""atType"": {""$exists"": true, ""$ne"": null, ""$not"": {""$size"": 0}}}}}",,
 "books[?@.title == ""chuck"" || @.title == ""norris""]","{""books"": {""$elemMatch"": {""$or"": [{""title"": ""chuck""}, {""title"": ""norris""}]}}}",,support for nested or expressions not planned atm.
 "color == ""red"" || number == 10","{""$or"": [{""color"": ""red""}, {""number"": 10}]}",,
 "color == ""red"" || color == ""blue""","{""$or"": [{""color"": ""red""}, {""color"": ""blue""}]}",,


### PR DESCRIPTION
Currently, the Postprocessors ignore nested selectors in assertions (for example in the elemMatch).
This PR aims to resolve this issue.

I also added a test to verify the previously faulty behavior has been fixed